### PR TITLE
New site icons and better icon usage

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -41,13 +41,13 @@
       breakLength: 0
     },
 	siteIcons: {
-		"news.ycombinator.com": "y-combinator",
-		"youtube.com": "youtube-play",
-		"reddit.com": "reddit",
-		"tumblr.com": "tumblr",
-		"facebook.com": "facebook",
-		"messenger.com": "comments-o",
-		"twitter.com": "twitter"
+		"ycombinator": "y-combinator",
+		"youtube": "youtube-play",
+		"reddit": "reddit",
+		"tumblr": "tumblr",
+		"facebook": "facebook",
+		"messenger": "comments-o",
+		"twitter": "twitter"
 	}
   }
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -40,14 +40,43 @@
       breakStart: 0, // the beginning of time (kinda)
       breakLength: 0
     },
+	// for siteIcons, please include icon without border
 	siteIcons: {
-		"ycombinator": "y-combinator",
-		"youtube": "youtube-play",
-		"reddit": "reddit",
-		"tumblr": "tumblr",
+		"amazon": "amazon",
+		"delicious": "delicious",
+		"deviantart": "deviantart",
+		"digg": "digg",
+		"dribble": "dribble",
 		"facebook": "facebook",
+		"flickr": "flickr",
+		"forumbee": "forumbee",
+		"foursquare": "foursquare",
+		"getpocket": "getpocket",
+		"plus.google": "google-plus",
+		"gratipay": "gratiplay",
+		"instagram": "instagram",
+		"last.fm": "lastfm",
+		"medium": "medium",
 		"messenger": "comments-o",
-		"twitter": "twitter"
+		"pinterest": "pinterest",
+		"reddit": "reddit-alien",
+		"skype": "skype",
+		"slack": "slack",
+		"snapchat": "snapchat-ghost",
+		"steampowered": "steam",
+		"stumbleupon": "stumbleupon",
+		"tumblr": "tumblr",
+		"twitter": "twitter",
+		"twitch": "twitch",
+		"vimeo": "vimeo",
+		"vine": "vine",
+		"wechat": "wechat",
+		"whatsapp": "whatsapp",
+		"wordpress": "wordpress",
+		"xing": "xing",
+		"yahoo": "yahoo",
+		"ycombinator": "hacker-news",
+		"youtube": "youtube-play"
 	}
   }
 

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -46,15 +46,22 @@ chrome.storage.sync.get(configQueries, (data) => {
 		var value = document.querySelector("#newSiteInput").value
 		document.querySelector("#newSiteInput").value = ""
 		if(this.distractions.filter(function(item) { return item.name == value }).length >= 1)
-			return;
+		  return;
 		this.distractions.push({name: value, enabled: true})
 		this.updateConfig()
 	  },
 	  removeSite(siteName) {
 	  	this.distractions = this.distractions.filter(function(item) {
-			return item.name != siteName;
+		  return item.name != siteName;
 		});
 		this.updateConfig()
+	  },
+	  findIcon(siteName) {
+		for(var url in this.siteIcons) {
+		  if(siteName.indexOf(url) >= 0)
+		    return this.siteIcons[url]
+		}
+		return false
 	  }
     }
   })

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -45,6 +45,8 @@ chrome.storage.sync.get(configQueries, (data) => {
 		  return
 		var value = document.querySelector("#newSiteInput").value
 		document.querySelector("#newSiteInput").value = ""
+		if(this.distractions.filter(function(item) { return item.name == value }).length >= 1)
+			return;
 		this.distractions.push({name: value, enabled: true})
 		this.updateConfig()
 	  },

--- a/src/view/popup.html
+++ b/src/view/popup.html
@@ -26,8 +26,8 @@
 	  <div id="siteContainer" class="clearfix">
 		<div v-for="site in distractions" @click="toggleSite($index)" v-bind:class="{'disabled':!site.enabled,'siteList':true}" title="Click to {{ site.enabled ? 'unblock site' : 'block site' }}">
 		  {{ site.name }}
-		  <span v-if="siteIcons[site.name]">
-			<i v-bind:class='["faSiteIcon","fa","fa-"+siteIcons[site.name]]'></i>
+		  <span v-if="findIcon(site.name) !== false">
+			<i v-bind:class='["faSiteIcon","fa","fa-"+findIcon(site.name)]'></i>
 		  </span>
 		  <span class="fa-stack closeButton" @click="removeSite(site.name)" title="Remove site blocking">
 			<i class="fa fa-circle fa-stack-2x closeButtonCircle"></i>


### PR DESCRIPTION
I added a ton of social-media site icons to the list (e.g. try blocking "yahoo.com" or "vine.co")

I also made it so that the icons do not match exact URLs&mdash; instead, it checks to see if it is _contained_ within the URL. For example:
- Behavior before: "facebook.com" matched blocked URL "facebook.com" but not "https://www.facebook.com/profile.php"
- Behavior now: "facebook" maches both blocked URLs "facebook.com" and "https://www.facebook.com/profile.php
